### PR TITLE
Update index.txt

### DIFF
--- a/index.txt
+++ b/index.txt
@@ -30,5 +30,4 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`
 * :ref:`search`


### PR DESCRIPTION
genindex link is broken and supposed to be used for python modules.
It serve no use to Intermine user documentation.