### PR TITLE
added alt text to images

### DIFF
--- a/tutorial/exercise1/exercise1.txt
+++ b/tutorial/exercise1/exercise1.txt
@@ -12,15 +12,15 @@ Use HumanMine for this exercise
 
 1. Search for one or more of the following using the keyword search (result for PPARG only shown below):
 
-1. **PPARG**
-2. **rs10509540**
-3. ***insulin***
+* **PPARG**
+* **rs10509540**
+* ***insulin***
 
 2. Filter and create a list:
 
-1. **Search for *diabetes***
-2. **Filter for publications**
-3. **Make a list of the publications**
+* **Search for *diabetes***
+* **Filter for publications**
+* **Make a list of the publications**
 
 
 Need a hint?  Take a look at :ref:`quicksearch`
@@ -37,15 +37,19 @@ Human PPARG is the first gene result returned when HumanMine is searched for PPA
 
 
 .. image:: ../../_images/exercise1.png
+  :alt: Search results for PPARG
 
 
 
 **2. Filter and create a list:**
 
 .. image:: ../../_images/exercise1b.png
+  :alt: Search results for diabetes
+
 
 
 **3. Use the checkbox in the header to select all the publications and make a list.**
 
 
 .. image:: ../../_images/exercise1c.png
+  :alt: Search result for publications category


### PR DESCRIPTION
## Description of PR

I noticed the current user documentation images do not have alternate text which is a disadvantage to screen readers and makes the docs not accessible.
I have added alt text for the tutorial for exercise1. Please help me review @rachellyne @danielabutano @uosl, so I can kindly go ahead with adding it across the repository.

Thanks.